### PR TITLE
Added functionality to return acoustic and language model costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,20 @@ big clusters.
 
 For installation instructions, examples and documentation visit [Vosk
 Website](https://alphacephei.com/vosk).
+
+# Test the functionality implemented in this repository using C scripts
+
+1. Clone the `ETS fork` of the `Vosk API` repositiory [https://github.com/EducationalTestingService/vosk-api](https://github.com/EducationalTestingService/vosk-api).
+
+2. The docker image for building Kaldi and the Python wheels is located in the cloned repository under `travis`.
+
+   Build and run the docker image as follows:
+
+   ```
+   docker build --file Dockerfile.manylinux --tag alphacep/kaldi-manylinux:latest .
+   docker run -ti -v $(pwd)/..:/io alphacep/kaldi-manylinux /bin/bash
+   ```
+
+3. Inside the docker container under the `io/src` folder run `KALDI_ROOT=/opt/kaldi make all` to compile your changes.
+
+4. Go to the `io/c` folder and run `KALDI_ROOT=/opt/kaldi make all` to compile the C scripts. This should create an executable for the C script. To test the custom functionalities built by ETS team, run the command `./test_phone_results`. This should print out the expected results for the script.

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Website](https://alphacephei.com/vosk).
 1. Clone the `ETS fork` of the `Vosk API` repository [https://github.com/EducationalTestingService/vosk-api](https://github.com/EducationalTestingService/vosk-api).
 
 2. If you are using your own custom ASR model, copy the model into the `model` directory in the structure shared in the section `Model structure` [on VOSK-API website](https://alphacephei.com/vosk/models). Alternatively, you can download one of the [open-source ASR models available on Vosk-API website](https://alphacephei.com/vosk/models) and copy them into the `model` directory.
+NOTE: To be able to extract phoneme labels and timestamps, you need to include the `phones.txt` file that was used during ASR model buildiong in the `model/graph` directory, so Vosk's open source models may not work out of the box.
 
 3. Add the audio file to be used to test the C test script under `c` and rename the file to `test.wav` to use the script as is. 
 

--- a/README.md
+++ b/README.md
@@ -27,9 +27,13 @@ Website](https://alphacephei.com/vosk).
 
 # Test the functionality implemented in this repository using C scripts
 
-1. Clone the `ETS fork` of the `Vosk API` repositiory [https://github.com/EducationalTestingService/vosk-api](https://github.com/EducationalTestingService/vosk-api).
+1. Clone the `ETS fork` of the `Vosk API` repository [https://github.com/EducationalTestingService/vosk-api](https://github.com/EducationalTestingService/vosk-api).
 
-2. The docker image for building Kaldi and the Python wheels is located in the cloned repository under `travis`.
+2. If you are using your own custom ASR model, copy the model into the `model` directory in the structure shared in the section `Model structure` [on VOSK-API website](https://alphacephei.com/vosk/models). Alternatively, you can download one of the [open-source ASR models available on Vosk-API website](https://alphacephei.com/vosk/models) and copy them into the `model` directory.
+
+3. Add the audio file to be used to test the C test script under `c` and rename the file to `test.wav` to use the script as is. 
+
+4. The docker image for building Kaldi and the Python wheels is located in the cloned repository under `travis`.
 
    Build and run the docker image as follows:
 
@@ -38,6 +42,6 @@ Website](https://alphacephei.com/vosk).
    docker run -ti -v $(pwd)/..:/io alphacep/kaldi-manylinux /bin/bash
    ```
 
-3. Inside the docker container under the `io/src` folder run `KALDI_ROOT=/opt/kaldi make all` to compile your changes.
+5. Inside the docker container under the `io/src` folder run `KALDI_ROOT=/opt/kaldi make all` to compile your changes.
 
-4. Go to the `io/c` folder and run `KALDI_ROOT=/opt/kaldi make all` to compile the C scripts. This should create an executable for the C script. To test the custom functionalities built by ETS team, run the command `./test_phone_results`. This should print out the expected results for the script.
+6. Go to the `io/c` folder and run `KALDI_ROOT=/opt/kaldi make all` to compile the C scripts. This should create an executable for the C script. To test the custom functionalities built by ETS team, run the command `./test_phone_results`. This should print out the expected results for the script.

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ Website](https://alphacephei.com/vosk).
 
 1. Clone the `ETS fork` of the `Vosk API` repository [https://github.com/EducationalTestingService/vosk-api](https://github.com/EducationalTestingService/vosk-api).
 
-2. If you are using your own custom ASR model, copy the model into the `model` directory in the structure shared in the section `Model structure` [on VOSK-API website](https://alphacephei.com/vosk/models). Alternatively, you can download one of the [open-source ASR models available on Vosk-API website](https://alphacephei.com/vosk/models) and copy them into the `model` directory.
-NOTE: To be able to extract phoneme labels and timestamps, you need to include the `phones.txt` file that was used during ASR model buildiong in the `model/graph` directory, so Vosk's open source models may not work out of the box.
+2. If you are using your own custom ASR model, copy the model into the `model` directory in the structure shared in the section `Model structure` [on VOSK-API website](https://alphacephei.com/vosk/models). Alternatively, you can download one of the [open-source ASR models available on Vosk-API website](https://alphacephei.com/vosk/models),  uncompress the downloaded zip file and, rename the containing directory to `model`.
+**NOTE**: To be able to extract phoneme labels and timestamps, you need to include the `phones.txt` file that was used during ASR model buildiong in the `model/graph` directory, so Vosk's open source models may not work out of the box.
 
 3. Add the audio file to be used to test the C test script under `c` and rename the file to `test.wav` to use the script as is. 
 
@@ -45,4 +45,4 @@ NOTE: To be able to extract phoneme labels and timestamps, you need to include t
 
 5. Inside the docker container under the `io/src` folder run `KALDI_ROOT=/opt/kaldi make all` to compile your changes.
 
-6. Go to the `io/c` folder and run `KALDI_ROOT=/opt/kaldi make all` to compile the C scripts. This should create an executable for the C script. To test the custom functionalities built by ETS team, run the command `./test_phone_results`. This should print out the expected results for the script.
+6. Go to the `io/c` folder `ln -s ../model .` to symlink the model directory you created in step 2 inside this folder. Next, run `KALDI_ROOT=/opt/kaldi make all` to compile the C scripts. This should create an executable for the C script. To test the custom functionalities built by ETS team, run the command `./test_phone_results`. This should print out the expected results for the script.

--- a/c/Makefile
+++ b/c/Makefile
@@ -1,7 +1,7 @@
 CFLAGS=-I../src
 LDFLAGS=-L../src -lvosk -ldl -lpthread -Wl,-rpath=../src
 
-all: test_vosk test_vosk_speaker
+all: test_vosk test_vosk_speaker test_phone_results
 
 test_vosk: test_vosk.o
 	g++ $^ -o $@ $(LDFLAGS)
@@ -9,8 +9,10 @@ test_vosk: test_vosk.o
 test_vosk_speaker: test_vosk_speaker.o
 	g++ $^ -o $@ $(LDFLAGS)
 
+test_phone_results: test_phone_results.o
+	g++ $^ -o $@ $(LDFLAGS)
 %.o: %.c
 	g++ $(CFLAGS) -c -o $@ $<
 
 clean:
-	rm -f *.o *.a test_vosk test_vosk_speaker
+	rm -f *.o *.a test_vosk test_vosk_speaker test_phone_results

--- a/c/test_phone_results.c
+++ b/c/test_phone_results.c
@@ -1,0 +1,30 @@
+#include <vosk_api.h>
+#include <stdio.h>
+
+int main() {
+    FILE *wavin;
+    char buf[3200];
+    int nread, final;
+
+    VoskModel *model = vosk_model_new("model");
+    VoskRecognizer *recognizer = vosk_recognizer_new(model, 16000.0);
+    vosk_recognizer_set_result_opts(recognizer, "phones");
+
+    wavin = fopen("test.wav", "rb");
+    fseek(wavin, 44, SEEK_SET);
+    while (!feof(wavin)) {
+         nread = fread(buf, 1, sizeof(buf), wavin);
+         final = vosk_recognizer_accept_waveform(recognizer, buf, nread);
+         if (final) {
+             printf("%s\n", vosk_recognizer_result(recognizer));
+         } else {
+             printf("%s\n", vosk_recognizer_partial_result(recognizer));
+         }
+    }
+    printf("%s\n", vosk_recognizer_final_result(recognizer));
+
+    vosk_recognizer_free(recognizer);
+    vosk_model_free(model);
+    fclose(wavin);
+    return 0;
+}

--- a/c/test_phone_results.c
+++ b/c/test_phone_results.c
@@ -8,7 +8,7 @@ int main() {
 
     VoskModel *model = vosk_model_new("model");
     VoskRecognizer *recognizer = vosk_recognizer_new(model, 16000.0);
-    vosk_recognizer_set_result_opts(recognizer, "phones");
+    vosk_recognizer_set_result_options(recognizer, "phones");
 
     wavin = fopen("test.wav", "rb");
     fseek(wavin, 44, SEEK_SET);

--- a/src/kaldi_recognizer.cc
+++ b/src/kaldi_recognizer.cc
@@ -17,6 +17,7 @@
 #include "fstext/fstext-utils.h"
 #include "lat/sausages.h"
 #include "language_model.h"
+#include "hmm/hmm-utils.h"
 
 
 using namespace fst;
@@ -414,8 +415,95 @@ bool KaldiRecognizer::GetSpkVector(Vector<BaseFloat> &out_xvector, int *num_spk_
     return true;
 }
 
+// Customized CompactLatticeToWordProns method in Kaldi to return weights
+static bool CompactLatticeToWordPronsWeight(
+     const TransitionModel &tmodel,
+     const CompactLattice &clat,
+     std::vector<int32> *words,
+     std::vector<int32> *begin_times,
+     std::vector<int32> *lengths,
+     std::vector<std::vector<int32> > *prons,
+     std::vector<std::vector<int32> > *phone_lengths,
+     std::vector<kaldi::BaseFloat> *lm_costs,
+     std::vector<kaldi::BaseFloat> *acoustic_costs) {
+   words->clear();
+   begin_times->clear();
+   lengths->clear();
+   prons->clear();
+   phone_lengths->clear();
+   typedef CompactLattice::Arc Arc;
+   typedef Arc::Label Label;
+   typedef CompactLattice::StateId StateId;
+   typedef CompactLattice::Weight Weight;
+   using namespace fst;
+   StateId state = clat.Start();
+   int32 cur_time = 0;
+   if (state == kNoStateId) {
+     KALDI_WARN << "Empty lattice.";
+     return false;
+   }
+   while (1) {
+     Weight final = clat.Final(state);
+     size_t num_arcs = clat.NumArcs(state);
+     if (final != Weight::Zero()) {
+       if (num_arcs != 0) {
+         KALDI_WARN << "Lattice is not linear.";
+         return false;
+       }
+       if (! final.String().empty()) {
+         KALDI_WARN << "Lattice has alignments on final-weight: probably "
+             "was not word-aligned (alignments will be approximate)";
+       }
+       return true;
+     } else {
+       if (num_arcs != 1) {
+         KALDI_WARN << "Lattice is not linear: num-arcs = " << num_arcs;
+         return false;
+       }
 
-void ComputePhoneInfo(const TransitionModel &tmodel, const CompactLattice &clat, const fst::SymbolTable &word_syms_, const fst::SymbolTable &phone_symbol_table_, std::vector<std::vector<std::string> > *phoneme_labels, std::vector<std::vector<int32> > *phone_lengths)
+       // Iterate over each arc in the lattice, create and return
+       // arrays containing word ids, start times, word lengths,
+       // LM and acoustic costs
+       fst::ArcIterator<CompactLattice> aiter(clat, state);
+       const Arc &arc = aiter.Value();
+       Label word_id = arc.ilabel; // Note: ilabel==olabel, since acceptor.
+       // Also note: word_id may be zero; we output it anyway.
+       int32 length = arc.weight.String().size();
+ 
+       words->push_back(word_id);
+       begin_times->push_back(cur_time);
+       lengths->push_back(length);
+
+       //We return LM and acoustic costs in addition to phoneme information
+       // from `ComputePhoneInfo`
+       lm_costs->push_back(arc.weight.Weight().Value1());
+       acoustic_costs->push_back(arc.weight.Weight().Value2());
+
+       const std::vector<int32> &arc_alignment = arc.weight.String();
+       std::vector<std::vector<int32> > split_alignment;
+       //Split up the TransitionIds in alignment into their individual phones
+       SplitToPhones(tmodel, arc_alignment, &split_alignment);
+       std::vector<int32> phones(split_alignment.size());
+       std::vector<int32> plengths(split_alignment.size());
+
+       // Here we create an array of phonemes and their corresponding lengths
+       // used to compute phone timestamps in `ComputePhoneInfo`
+       for (size_t i = 0; i < split_alignment.size(); i++) {
+         KALDI_ASSERT(!split_alignment[i].empty());
+         phones[i] = tmodel.TransitionIdToPhone(split_alignment[i][0]);
+         plengths[i] = split_alignment[i].size();
+       }
+       prons->push_back(phones);
+       phone_lengths->push_back(plengths);
+ 
+       cur_time += length;
+       state = arc.nextstate;
+     }
+   }
+ }
+
+
+void ComputePhoneInfo(const TransitionModel &tmodel, const CompactLattice &clat, const fst::SymbolTable &word_syms_, const fst::SymbolTable &phone_symbol_table_, std::vector<std::vector<std::string> > *phoneme_labels, std::vector<std::vector<int32> > *phone_lengths, std::vector<kaldi::BaseFloat> *lm_costs, std::vector<kaldi::BaseFloat> *acoustic_costs)
 {    
     //This function computes the phone information i.e. phone labels and lengths 
     vector<int32> words_ph_ids, times_lat, lengths;
@@ -424,8 +512,8 @@ void ComputePhoneInfo(const TransitionModel &tmodel, const CompactLattice &clat,
     kaldi::CompactLattice best_path;
     kaldi::CompactLatticeShortestPath(clat, &best_path);
 
-    kaldi::CompactLatticeToWordProns(tmodel, best_path, &words_ph_ids, &times_lat, &lengths,
-                                       &prons, phone_lengths);
+    CompactLatticeToWordPronsWeight(tmodel, best_path, &words_ph_ids, &times_lat, &lengths,
+                                       &prons, phone_lengths, lm_costs, acoustic_costs);
     
 
     for (size_t z = 0; z < words_ph_ids.size(); z++) {
@@ -458,11 +546,13 @@ const char *KaldiRecognizer::MbrResult(CompactLattice &rlat)
     std::vector<std::vector<std::string> > phoneme_labels;
     std::vector<std::vector<int32> > phone_lengths;
     int phon_vec_size = 1;
+    std::vector<kaldi::BaseFloat> lm_costs;
+    std::vector<kaldi::BaseFloat> acoustic_costs;
 
     if (model_->phone_syms_loaded_){  
         //Compute phone info if phone symbol table is provided  
 
-        ComputePhoneInfo(*model_->trans_model_, aligned_lat, *model_->word_syms_, *model_->phone_symbol_table_, &phoneme_labels, &phone_lengths);
+        ComputePhoneInfo(*model_->trans_model_, aligned_lat, *model_->word_syms_, *model_->phone_symbol_table_, &phoneme_labels, &phone_lengths, &lm_costs, &acoustic_costs);
         phon_vec_size = phoneme_labels.size();
         mbr_options.print_silence = true; //Print silences in the word-level outputs only if you need phone outputs
         mbr_options.decode_mbr = false; // Turn off MBR decoding if you want to print out phone information
@@ -483,14 +573,13 @@ const char *KaldiRecognizer::MbrResult(CompactLattice &rlat)
     for (int i = 0; i < size; i++) {
         json::JSON word;
 
-        if (words_) {
+        /*if (words_) {
             word["word"] = model_->word_syms_->Find(word_ids[i]);
             word["start"] = samples_round_start_ / sample_frequency_ + (frame_offset_ + times[i].first) * 0.03;
             word["end"] = samples_round_start_ / sample_frequency_ + (frame_offset_ + times[i].second) * 0.03;
             word["conf"] = conf[i];
             obj["result"].append(word);
-        }
-
+        }*/
     
         //When printing silences some extra silence words that we call "gaps" that have length of 0 seconds 
         //get printed out so we filter them out
@@ -501,11 +590,14 @@ const char *KaldiRecognizer::MbrResult(CompactLattice &rlat)
             word["word"] = model_->word_syms_->Find(word_ids[i]);
             word["start"] = samples_round_start_ / sample_frequency_ + (frame_offset_ + times[i].first) * 0.03;
             word["end"] = samples_round_start_ / sample_frequency_ + (frame_offset_ + times[i].second) * 0.03;
-            word["conf"] = conf[i];
+            word["conf"] = conf[i]; 
 
-            if (model_->phone_syms_loaded_){ //Add phone info to json if phone symbol table is provided
+            if (model_->phone_syms_loaded_ && !words_){ //Add phone info to json if phone symbol table is provided
                 kaldi::BaseFloat phone_start_time = 0.0;
                 kaldi::BaseFloat phone_end_time = 0.0;
+                // Also add LM and Acoustic costs to the result json
+                word["lm_cost"] = lm_costs[phone_ptr]; 
+                word["acoustic_cost"] = acoustic_costs[phone_ptr];
                         
                 //If there are silences without phone output (since they are coming from different places) then set the label and timestamps
                 if (word_ids[i] == 0 && phoneme_labels[phone_ptr][0] != "SIL"){

--- a/src/kaldi_recognizer.h
+++ b/src/kaldi_recognizer.h
@@ -47,6 +47,7 @@ class KaldiRecognizer {
         KaldiRecognizer(Model *model, float sample_frequency, char const *grammar);
         ~KaldiRecognizer();
         void SetMaxAlternatives(int max_alternatives);
+        void SetResultOptions(const char *result_opts);
         void SetSpkModel(SpkModel *spk_model);
         void SetWords(bool words);
         bool AcceptWaveform(const char *data, int len);
@@ -56,7 +57,7 @@ class KaldiRecognizer {
         const char* FinalResult();
         const char* PartialResult();
         void Reset();
-
+        
     private:
         void InitState();
         void InitRescoring();
@@ -93,6 +94,7 @@ class KaldiRecognizer {
 
         // Other
         int max_alternatives_ = 0; // Disable alternatives by default
+        const char *result_opts_ = "words"; // By default enable only word-level results
         bool words_ = false;
 
         float sample_frequency_;

--- a/src/model.cc
+++ b/src/model.cc
@@ -292,7 +292,7 @@ void Model::ReadDataFiles()
         word_syms_ = g_fst_->OutputSymbols();
     }
     if (!word_syms_) {
-        KALDI_LOG << "Loading words from xxxx" << word_syms_rxfilename_;
+        KALDI_LOG << "Loading words from " << word_syms_rxfilename_;
         if (!(word_syms_ = fst::SymbolTable::ReadText(word_syms_rxfilename_)))
             KALDI_ERR << "Could not read symbol table from file "
                       << word_syms_rxfilename_;

--- a/src/model.cc
+++ b/src/model.cc
@@ -175,6 +175,7 @@ void Model::ConfigureV1()
     rnnlm_feat_embedding_rxfilename_ = model_path_str_ + "/rnnlm/feat_embedding.final.mat";
     rnnlm_config_rxfilename_ = model_path_str_ + "/rnnlm/special_symbol_opts.conf";
     rnnlm_lm_rxfilename_ = model_path_str_ + "/rnnlm/final.raw";
+    phone_syms_rxfilename_ = model_path_str_ + "/graph/phones.txt";
 }
 
 void Model::ConfigureV2()
@@ -204,6 +205,7 @@ void Model::ConfigureV2()
     rnnlm_feat_embedding_rxfilename_ = model_path_str_ + "/rnnlm/feat_embedding.final.mat";
     rnnlm_config_rxfilename_ = model_path_str_ + "/rnnlm/special_symbol_opts.conf";
     rnnlm_lm_rxfilename_ = model_path_str_ + "/rnnlm/final.raw";
+    phone_syms_rxfilename_ = model_path_str_ + "/graph/phones.txt";
 }
 
 void Model::ReadDataFiles()
@@ -290,7 +292,7 @@ void Model::ReadDataFiles()
         word_syms_ = g_fst_->OutputSymbols();
     }
     if (!word_syms_) {
-        KALDI_LOG << "Loading words from " << word_syms_rxfilename_;
+        KALDI_LOG << "Loading words from xxxx" << word_syms_rxfilename_;
         if (!(word_syms_ = fst::SymbolTable::ReadText(word_syms_rxfilename_)))
             KALDI_ERR << "Could not read symbol table from file "
                       << word_syms_rxfilename_;
@@ -302,6 +304,16 @@ void Model::ReadDataFiles()
         KALDI_LOG << "Loading winfo " << winfo_rxfilename_;
         kaldi::WordBoundaryInfoNewOpts opts;
         winfo_ = new kaldi::WordBoundaryInfo(opts, winfo_rxfilename_);
+    }
+
+    phone_symbol_table_ = NULL;
+    phone_syms_loaded_ = false;
+    //Providing phones.txt symbol table is optional and currently not required by Vosk
+    //If you provide it by default the phone information will be computed
+    if (stat(phone_syms_rxfilename_.c_str(), &buffer) == 0) {
+        KALDI_LOG << "Loading phonemes from " << phone_syms_rxfilename_;
+        phone_symbol_table_  = fst::SymbolTable::ReadText(phone_syms_rxfilename_);
+        phone_syms_loaded_ = true;
     }
 
     if (stat(carpa_rxfilename_.c_str(), &buffer) == 0) {

--- a/src/model.h
+++ b/src/model.h
@@ -69,6 +69,7 @@ protected:
     string fbank_conf_rxfilename_;
     string global_cmvn_stats_rxfilename_;
     string pitch_conf_rxfilename_;
+    string phone_syms_rxfilename_;
 
     string rnnlm_word_feats_rxfilename_;
     string rnnlm_feat_embedding_rxfilename_;
@@ -87,6 +88,8 @@ protected:
     bool word_syms_loaded_ = false;
     kaldi::WordBoundaryInfo *winfo_ = nullptr;
     vector<int32> disambig_;
+    const fst::SymbolTable *phone_symbol_table_;
+    bool phone_syms_loaded_;
 
     fst::Fst<fst::StdArc> *hclg_fst_ = nullptr;
     fst::Fst<fst::StdArc> *hcl_fst_ = nullptr;

--- a/src/vosk_api.cc
+++ b/src/vosk_api.cc
@@ -96,6 +96,11 @@ void vosk_recognizer_set_max_alternatives(VoskRecognizer *recognizer, int max_al
     ((KaldiRecognizer *)recognizer)->SetMaxAlternatives(max_alternatives);
 }
 
+void vosk_recognizer_set_result_options(VoskRecognizer *recognizer, const char *result_opts)
+{
+    ((KaldiRecognizer *)recognizer)->SetResultOptions(result_opts);
+}
+
 void vosk_recognizer_set_words(VoskRecognizer *recognizer, int words)
 {
     ((KaldiRecognizer *)recognizer)->SetWords((bool)words);

--- a/src/vosk_api.h
+++ b/src/vosk_api.h
@@ -152,67 +152,84 @@ void vosk_recognizer_set_max_alternatives(VoskRecognizer *recognizer, int max_al
 
 /** Configures recognizer result options (i.e. whether to print word-level results or word and phone level results together)
  * With phone level results (i.e. if configured with "phones" option)
+ * Also additionally returns acoustic costs and language model costs per word 
  * <pre>
  *    {
  *     "result" : [{
- *         "conf" : 0.998335,
+ *         "acoustic_cost" : -96.086105,
+ *         "conf" : 0.997802,
  *         "end" : 0.450000,
+ *         "lm_cost" : 29.145569,
  *         "phone_end" : [0.450000],
  *         "phone_label" : ["SIL"],
  *         "phone_start" : [0.000000],
  *         "start" : 0.000000,
  *         "word" : "<eps>"
  *       }, {
- *         "conf" : 0.998324,
+ *         "acoustic_cost" : -45.020378,
+ *         "conf" : 0.997153,
  *         "end" : 0.600000,
+ *         "lm_cost" : 21.490904,
  *         "phone_end" : [0.540000, 0.600000],
  *         "phone_label" : ["DH_B", "AH1_E"],
  *         "phone_start" : [0.450000, 0.540000],
  *         "start" : 0.450000,
  *         "word" : "THE"
  *       }, {
- *         "conf" : 0.574095,
+ *         "acoustic_cost" : -21.904301,
+ *         "conf" : 0.553237,
  *         "end" : 1.200000,
+ *         "lm_cost" : 6.307260,
  *         "phone_end" : [0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000, 1.200000],
  *         "phone_label" : ["S_B", "T_I", "UW1_I", "D_I", "AH0_I", "N_I", "T_I", "S_E"],
  *         "phone_start" : [0.600000, 0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000],
  *         "start" : 0.600000,
  *         "word" : "STUDENT'S"
  *       }, {
- *         "conf" : 0.923344,
+ *         "acoustic_cost" : 0.000000,
+ *         "conf" : 0.922575,
  *         "end" : 1.260000,
- *         "phone_end" : [1.260111],
+ *         "lm_cost" : 0.000000,
+ *         "phone_end" : [1.260130],
  *         "phone_label" : ["SIL"],
- *         "phone_start" : [1.200111],
- *         "start" : 1.200111,
+ *         "phone_start" : [1.200130],
+ *         "start" : 1.200130,
  *         "word" : "<eps>"
  *       }, {
+ *         "acoustic_cost" : -22.304758,
  *         "conf" : 1.000000,
  *         "end" : 1.800000,
+ *         "lm_cost" : 8.857350,
  *         "phone_end" : [1.440000, 1.500000, 1.590000, 1.680000, 1.800000],
  *         "phone_label" : ["S_B", "T_I", "AH1_I", "D_I", "IY0_E"],
  *         "phone_start" : [1.260000, 1.440000, 1.500000, 1.590000, 1.680000],
  *         "start" : 1.260000,
  *         "word" : "STUDY"
  *       }, {
+ *         "acoustic_cost" : 0.000000,
  *         "conf" : 1.000000,
  *         "end" : 1.860000,
+ *         "lm_cost" : 0.000000,
  *         "phone_end" : [1.860000],
  *         "phone_label" : ["AH0_S"],
  *         "phone_start" : [1.800000],
  *         "start" : 1.800000,
  *         "word" : "A"
  *       }, {
+ *         "acoustic_cost" : -105.112961,
  *         "conf" : 1.000000,
  *         "end" : 2.190000,
+ *         "lm_cost" : 12.693477,
  *         "phone_end" : [1.980000, 2.100000, 2.190000],
  *         "phone_label" : ["L_B", "AA1_I", "T_E"],
  *         "phone_start" : [1.860000, 1.980000, 2.100000],
  *         "start" : 1.860000,
  *         "word" : "LOT"
  *       }, {
+ *        "acoustic_cost" : 0.000000,
  *         "conf" : 1.000000,
  *         "end" : 2.880000,
+ *         "lm_cost" : 4.726567,
  *         "phone_end" : [2.880000],
  *         "phone_label" : ["SIL"],
  *         "phone_start" : [2.190000],

--- a/src/vosk_api.h
+++ b/src/vosk_api.h
@@ -150,6 +150,84 @@ void vosk_recognizer_set_spk_model(VoskRecognizer *recognizer, VoskSpkModel *spk
  */
 void vosk_recognizer_set_max_alternatives(VoskRecognizer *recognizer, int max_alternatives);
 
+/** Configures recognizer result options (i.e. whether to print word-level results or word and phone level results together)
+ * With phone level results (i.e. if configured with "phones" option)
+ * <pre>
+ *    {
+ *     "result" : [{
+ *         "conf" : 0.998335,
+ *         "end" : 0.450000,
+ *         "phone_end" : [0.450000],
+ *         "phone_label" : ["SIL"],
+ *         "phone_start" : [0.000000],
+ *         "start" : 0.000000,
+ *         "word" : "<eps>"
+ *       }, {
+ *         "conf" : 0.998324,
+ *         "end" : 0.600000,
+ *         "phone_end" : [0.540000, 0.600000],
+ *         "phone_label" : ["DH_B", "AH1_E"],
+ *         "phone_start" : [0.450000, 0.540000],
+ *         "start" : 0.450000,
+ *         "word" : "THE"
+ *       }, {
+ *         "conf" : 0.574095,
+ *         "end" : 1.200000,
+ *         "phone_end" : [0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000, 1.200000],
+ *         "phone_label" : ["S_B", "T_I", "UW1_I", "D_I", "AH0_I", "N_I", "T_I", "S_E"],
+ *         "phone_start" : [0.600000, 0.720000, 0.810000, 0.870000, 0.930000, 0.990000, 1.080000, 1.110000],
+ *         "start" : 0.600000,
+ *         "word" : "STUDENT'S"
+ *       }, {
+ *         "conf" : 0.923344,
+ *         "end" : 1.260000,
+ *         "phone_end" : [1.260111],
+ *         "phone_label" : ["SIL"],
+ *         "phone_start" : [1.200111],
+ *         "start" : 1.200111,
+ *         "word" : "<eps>"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 1.800000,
+ *         "phone_end" : [1.440000, 1.500000, 1.590000, 1.680000, 1.800000],
+ *         "phone_label" : ["S_B", "T_I", "AH1_I", "D_I", "IY0_E"],
+ *         "phone_start" : [1.260000, 1.440000, 1.500000, 1.590000, 1.680000],
+ *         "start" : 1.260000,
+ *         "word" : "STUDY"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 1.860000,
+ *         "phone_end" : [1.860000],
+ *         "phone_label" : ["AH0_S"],
+ *         "phone_start" : [1.800000],
+ *         "start" : 1.800000,
+ *         "word" : "A"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 2.190000,
+ *         "phone_end" : [1.980000, 2.100000, 2.190000],
+ *         "phone_label" : ["L_B", "AA1_I", "T_E"],
+ *         "phone_start" : [1.860000, 1.980000, 2.100000],
+ *         "start" : 1.860000,
+ *         "word" : "LOT"
+ *       }, {
+ *         "conf" : 1.000000,
+ *         "end" : 2.880000,
+ *         "phone_end" : [2.880000],
+ *         "phone_label" : ["SIL"],
+ *         "phone_start" : [2.190000],
+ *         "start" : 2.190000,
+ *         "word" : "<eps>"
+ *       }],
+ *     "text" : " THE STUDENT'S STUDY A LOT"
+ *   }
+ * </pre>
+ *
+ * If configured with "words" option then result is same word-level MBR results. See vosk_recognizer_result() 
+ * </pre>
+ * * @param result_opts - result options to determine which recognition results to return
+ */
+void vosk_recognizer_set_result_options(VoskRecognizer *recognizer, const char *result_opts);
 
 /** Enables words with times in the output
  *


### PR DESCRIPTION
This PR addresses the following:

- Added custom method `CompactLatticeToWordPronsWeight` a version of Kaldi method `CompactLatticeToWordProns` to return acoustic and language model costs in addition to phone labels and timestamps. 
- If the phone result option is enabled then this method will also append the acoustic and language model costs to the output.
- The functionality can be tested by running the example script `test_phone_results.c` under the c scripts folder.